### PR TITLE
Fixed steadystate eigen for DenseOperators

### DIFF
--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -92,7 +92,8 @@ L
 """
 function eigenvector(L::DenseSuperOperator)
     d, v = Base.eig(L.data)
-    data = reshape(v[:,1], length(L.basis_r[1]), length(L.basis_r[2]))
+    index = findmin(abs(d))
+    data = reshape(v[:,index], length(L.basis_r[1]), length(L.basis_r[2]))
     return DenseOperator(L.basis_r[1], L.basis_r[2], data)
 end
 


### PR DESCRIPTION
The steadystate.eigen(L) function previously took the eigenvector of the first eigenvalue which is not necessarily the one closest to zero; fixed by finding the minimum of the absolute values.