### PR TITLE
Fix encoding error when using sphinx to build docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import unicode_literals
 import sys
 import os
 


### PR DESCRIPTION
When I followed the available instructions to build the documentation (i.e. cloning the `gh-pages` branch as described an installing your `sphinx-julia` package) I ran into the following error:
```
>> make html
sphinx-build -b html -d build/doctrees   source ../../QuantumOptics.jl-docs/html
Running Sphinx v1.4.6
WARNING: the config value 'copyright' is set to a string with non-ASCII characters; this can lead to Unicode errors occurring. Please use Unicode strings, e.g. u'Content'.
PyJulia not found - using slower alternative.
loading pickled environment... done
building [mo]: targets for 0 po files that are out of date

Encoding error:
'ascii' codec can't decode byte 0xc3 in position 18: ordinal not in range(128)
The full traceback has been saved in /tmp/sphinx-err-UOKOhp.log, if you want to report the issue to the developers.
Makefile:57: recipe for target 'html' failed
make: *** [html] Error 1
```
I tried several things, but finally [this post on stackoverflow](http://stackoverflow.com/questions/34029514/how-can-i-test-output-of-non-ascii-characters-using-sphinx-doctest) pointed me in the right direction. Adding `from __future__ import unicode_literals` in the first line of the `conf.py` file did the trick.
The error itself probably had something to do with the python version on my Linux distribution, the default encoding or something the like. Adding this line might help other people avoid this issue altogether.