### PR TITLE
Nlevel examples

### DIFF
--- a/examples/lazy.jl
+++ b/examples/lazy.jl
@@ -1,6 +1,6 @@
 require("../src/quantumoptics.jl")
 
-using quantumoptics
+using QuantumOptics
 
 srand(0)
 

--- a/examples/particle.jl
+++ b/examples/particle.jl
@@ -1,4 +1,4 @@
-using quantumoptics
+using QuantumOptics
 
 N = 200
 xmin = -10.

--- a/examples/particle2d.jl
+++ b/examples/particle2d.jl
@@ -1,4 +1,4 @@
-using quantumoptics
+using QuantumOptics
 
 N = 200
 xmin = -10.

--- a/examples/pumpedcavity.jl
+++ b/examples/pumpedcavity.jl
@@ -1,4 +1,4 @@
-using quantumoptics
+using QuantumOptics
 
 # System parameters for a pumped decaying cavity
 η = 0.9

--- a/examples/pumpedspin.jl
+++ b/examples/pumpedspin.jl
@@ -1,4 +1,4 @@
-using quantumoptics
+using QuantumOptics
 
 # System parameters for a single decaying spin
 ω0 = 1.

--- a/examples/raman.jl
+++ b/examples/raman.jl
@@ -1,0 +1,50 @@
+using QuantumOptics
+using PyPlot
+
+"""
+Example that illustrates the concept of a Raman transition. A Λ-scheme
+three-level atom is prepared in one of two ground states (state 1 in the
+following code) and is driven by a laser that is far-detuned from the
+transition to the excited state. It spontaneously decays into the other ground
+state.
+"""
+
+# Parameters
+γ₃ = 1.
+Ω = .5γ₃
+Δ₂ = 5γ₃
+Δ₃ = 0.0
+tmax = 800/γ₃
+dt = 0.1
+tlist = [0:dt:tmax;]
+
+# Basis and operators
+b = NLevelBasis(3)
+σ₁ = transition(b, 1, 2)
+σ₃ = transition(b, 3, 2)
+proj₂ = transition(b, 2, 2)
+proj₃ = σ₃*dagger(σ₃)
+
+# Hamiltonian and jump operators
+H = Δ₂*proj₂ + Δ₃*proj₃ + Ω*(σ₁ + dagger(σ₁))
+J = [sqrt(γ₃)*σ₃]
+
+# Initial state
+ψ₀ = nlevelstate(b, 1)
+
+# Time evolution
+tout, ρₜ = timeevolution.master(tlist, ψ₀, H, J)
+
+# Expectation values
+p1 = real(expect(σ₁*dagger(σ₁), ρₜ))
+p2 = real(expect(proj₂, ρₜ))
+p3 = real(expect(proj₃, ρₜ))
+
+# Plots
+clf()
+plot(tout, p1, "b", label="Initial ground state")
+plot(tout, p2, "k--", label="Excited state")
+plot(tout, p3, "r", label="Other ground state")
+axis([0, tmax, 0, 1])
+legend()
+show()

--- a/examples/v-atom-cavity.jl
+++ b/examples/v-atom-cavity.jl
@@ -1,0 +1,63 @@
+using QuantumOptics
+using PyPlot
+
+"""
+Example of a V-scheme three-level atom, where both transitions have the same
+frequency and are resonantly coupled to a cavity mode. One transition is
+resonantly driven from the side. The cavity is damped and the upper atomic
+levels weakly decay with the same rate.
+"""
+
+# Parameters
+Nc = 10
+κ = 1.
+Ω = κ/2.
+g = κ
+γ = κ/10.
+dt = 0.1
+tmax = 100/κ
+T = [0:dt:tmax;]
+
+# Bases and operators
+bc = FockBasis(Nc)
+ba = NLevelBasis(3) # Three-level atom: 1 is the ground state
+idc = identityoperator(bc)
+ida = identityoperator(ba)
+a = destroy(bc) ⊗ ida
+σ₂ = idc ⊗ transition(ba, 1, 2)
+σ₃ = idc ⊗ transition(ba, 1, 3)
+
+# Hamiltonian and jump operators
+H_int = g*(a*dagger(σ₂ + σ₃) + dagger(a)*(σ₂ + σ₃))
+H_pump = Ω*(σ₂ + dagger(σ₂))
+H = H_int + H_pump
+
+J = [sqrt(2κ)*a, sqrt(γ)*σ₂, sqrt(γ)*σ₃]
+
+# Initial state
+ψ₀ = fockstate(bc, 0) ⊗ nlevelstate(ba, 1)
+
+# Time evolution
+tout, ρt = timeevolution.master(T, ψ₀, H, J)
+
+# Expectation values: photon number and level occupation
+n = real(expect(dagger(a)*a, ρt))
+p1 = real(expect(idc ⊗ transition(ba, 1, 1), ρt))
+p2 = real(expect(dagger(σ₂)*σ₂, ρt))
+p3 = real(expect(dagger(σ₃)*σ₃, ρt))
+
+# Plots
+clf()
+
+subplot(211)
+plot(tout, n, label="n")
+legend()
+
+subplot(212)
+plot(tout, p1, "k--", label="Ground state")
+plot(tout, p2, "b", label="1st excited state (driven)")
+plot(tout, p3, "r", label="2nd excited state")
+axis([0, tmax, 0, 1])
+legend()
+
+show()


### PR DESCRIPTION
I added two example scripts for three-level atoms. While I was at it, I noticed that many of the `.jl` examples still had `using quantumoptics` instead of `QuantumOptics`, so I changed that as well. @bastikr please review and merge.