### PR TITLE
Add trace norm to eigenvector function for dense operators

### DIFF
--- a/src/steadystate.jl
+++ b/src/steadystate.jl
@@ -95,7 +95,8 @@ function eigenvector(L::DenseSuperOperator)
     d, v = Base.eig(L.data)
     index = findmin(abs(d))[2]
     data = reshape(v[:,index], length(L.basis_r[1]), length(L.basis_r[2]))
-    return DenseOperator(L.basis_r[1], L.basis_r[2], data)
+    op = DenseOperator(L.basis_r[1], L.basis_r[2], data)
+    return op/trace(op)
 end
 
 function eigenvector(L::SparseSuperOperator)


### PR DESCRIPTION
I ran into a problem when using the function `steadystate.eigenvector(L::DenseSuperOperator)`. It was producing wrong results. Digging around a bit and comparing it to the analogous function for sparse operators - which gave correct results - I found that the trace normalization was missing for dense operators.