### PR TITLE
Change links to docs to correct address

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Example
 
 More involved examples created using jupyter notebooks can be found at
 
-    https://bastikr.github.io/QuantumOptics.jl/examples.html
+    https://bastikr.github.io/QuantumOptics.jl/docs/examples.html
 
 
 Documentation
@@ -40,4 +40,4 @@ Documentation
 
 The documentation written with `Sphinx <http://www.sphinx-doc.org/>`_ using the `Sphinx-Julia <https://github.com/bastikr/sphinx-julia>`_ plugin is available at
 
-    https://bastikr.github.io/QuantumOptics.jl/
+    https://bastikr.github.io/QuantumOptics.jl/docs


### PR DESCRIPTION
The readme will be more thoroughly updated in the upcoming update of the documentation. For now, following issue #35 I simply changed the link addresses.