### PR TITLE
Faster calculation of expectation values.

### DIFF
--- a/src/operators_dense.jl
+++ b/src/operators_dense.jl
@@ -107,6 +107,14 @@ function states.normalize!(op::DenseOperator)
     return op
 end
 
+function operators.expect(op::DenseOperator, state::Operator)
+    result = Complex128(0.)
+    @inbounds for i=1:size(op.data, 1), j=1:size(op.data,2)
+        result += op.data[i,j]*state.data[j,i]
+    end
+    result
+end
+
 tensor(a::DenseOperator, b::DenseOperator) = DenseOperator(tensor(a.basis_l, b.basis_l), tensor(a.basis_r, b.basis_r), kron(a.data, b.data))
 tensor(a::Ket, b::Bra) = DenseOperator(a.basis, b.basis, reshape(kron(b.data, a.data), prod(a.basis.shape), prod(b.basis.shape)))
 

--- a/src/operators_sparse.jl
+++ b/src/operators_sparse.jl
@@ -79,6 +79,16 @@ function operators.ptrace(op::SparseOperator, indices::Vector{Int})
     SparseOperator(b_l, b_r, data)
 end
 
+function operators.expect(op::SparseOperator, state::DenseOperator)
+    result = Complex128(0.)
+    @inbounds for colindex = 1:op.data.n
+        for i=op.data.colptr[colindex]:op.data.colptr[colindex+1]-1
+            result += op.data.nzval[i]*state.data[colindex, op.data.rowval[i]]
+        end
+    end
+    result
+end
+
 tensor(a::SparseOperator, b::SparseOperator) = SparseOperator(tensor(a.basis_l, b.basis_l), tensor(a.basis_r, b.basis_r), kron(a.data, b.data))
 
 function permutesystems(rho::SparseOperator, perm::Vector{Int})

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -52,6 +52,14 @@ op_ = normalize!(op)
 @test op_ === op
 @test 1 == trace(op)
 
+# Test expect
+b = FockBasis(3) ⊗ SpinBasis(1//2)
+op = DenseOperator(b, b, rand(Complex128, length(b), length(b)))
+state = Ket(b, rand(Complex128, length(b)))
+@test expect(op, state) ≈ dagger(state)*op*state
+state = DenseOperator(b, b, rand(Complex128, length(b), length(b)))
+@test expect(op, state) ≈ trace(op*state)
+
 # Test operator exponential
 b = GenericBasis([3])
 op = DenseOperator(GenericBasis([3]), [1 3 2;5 2 2;-1 2 5])

--- a/test/test_sparseoperators.jl
+++ b/test/test_sparseoperators.jl
@@ -23,9 +23,17 @@ sz_dense = full(sz)
 @test typeof(sparse(sx_dense)) == SparseOperator
 @test sparse(sx_dense) == sx
 
+b = FockBasis(3) ⊗ SpinBasis(1//2)
+op = SparseOperator(b, b, sparse(rand(Complex128, length(b), length(b))))
+state = Ket(b, rand(Complex128, length(b)))
+@test expect(op, state) ≈ dagger(state)*op*state
+@test expect(op, state) ≈ dagger(state)*full(op)*state
+state = DenseOperator(b, b, rand(Complex128, length(b), length(b)))
+@test expect(op, state) ≈ trace(op*state)
+@test expect(op, state) ≈ trace(full(op)*state)
+
 b = FockBasis(3)
 I = identityoperator(b)
-
 
 a = TestOperator()
 


### PR DESCRIPTION
Instead of calculating the whole matrix A*B first calculate only the
diagonal entries.