### PR TITLE
CI: enforce downgrade runtest compatibility flags

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -27,3 +27,6 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          allow_reresolve: false
+          force_latest_compatible_version: false


### PR DESCRIPTION
## Summary
- add `allow_reresolve: false` to downgrade CI runtest step
- add `force_latest_compatible_version: false` to downgrade CI runtest step

This ensures downgrade CI runs without re-resolving to newer compatible versions.