### PR TITLE
Add Metal GPU tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,6 @@
 env:
   JULIA_NUM_THREADS: auto
+  PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH}
 
 secrets:
   CODECOV_TOKEN: CODECOV_TOKEN_qojulia
@@ -9,15 +10,12 @@ steps:
     plugins:
       - JuliaCI/julia#v1:
           version: "1"
-      - QuantumSavory/julia-xvfb#v1:
       - JuliaCI/julia-test#v1:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     env:
       JET_TEST: "{{matrix.JET_TEST}}"
-      CUDA_TEST: "{{matrix.CUDA_TEST}}"
-      AMDGPU_TEST: "{{matrix.AMDGPU_TEST}}"
-      OpenCL_TEST: "{{matrix.OPENCL_TEST}}"
+      GPU_TEST: "{{matrix.GPU_TEST}}"
     agents:
       queue: "{{matrix.QUEUE}}"
     matrix:
@@ -25,44 +23,38 @@ steps:
         LABEL: ["base tests"]
         QUEUE: ["default-queue"]
         JET_TEST: ["false"]
-        CUDA_TEST: ["false"]
-        AMDGPU_TEST: ["false"]
-        OPENCL_TEST: ["false"]
+        GPU_TEST: ["false"]
       adjustments:
         - with:
             LABEL: "JET"
             QUEUE: default-queue
             JET_TEST: true
-            CUDA_TEST: false
-            AMDGPU_TEST: false
-            OPENCL_TEST: false
+            GPU_TEST: false
         - with:
             LABEL: "CUDA"
             QUEUE: cuda
             JET_TEST: false
-            CUDA_TEST: true
-            AMDGPU_TEST: false
-            OPENCL_TEST: false
+            GPU_TEST: cuda
         - with:
             LABEL: "AMDGPU"
             QUEUE: rocm
             JET_TEST: false
-            CUDA_TEST: false
-            AMDGPU_TEST: true
-            OPENCL_TEST: false
+            GPU_TEST: amdgpu
         - with:
             LABEL: "OpenCL"
             QUEUE: default-queue
             JET_TEST: false
-            CUDA_TEST: false
-            AMDGPU_TEST: false
-            OPENCL_TEST: true
+            GPU_TEST: opencl
+        - with:
+            LABEL: "Metal"
+            QUEUE: macmini
+            JET_TEST: false
+            GPU_TEST: metal
 
   - label: "Downstream Tests - {{matrix.PACKAGE}}"
     plugins:
       - JuliaCI/julia#v1:
           version: "1"
-      - QuantumSavory/julia-xvfb#v1:
     command:
       - echo "Julia depot path $${JULIA_DEPOT_PATH}"
       - julia --project=$(mktemp -d) -e '

--- a/test/gpu/implementation/test_platform.jl
+++ b/test/gpu/implementation/test_platform.jl
@@ -4,11 +4,11 @@ include("imports.jl")
 include("utilities.jl")
 include("test_schroedinger_gpu.jl")
 
-function test_platform(AT, synchronize)
+function test_platform(AT, synchronize; kwargs...)
     """Run all GPU tests for the specified array type."""
-    
+
     @testset "QuantumOptics GPU Tests - $(AT)" begin
         # Test basic Schrödinger time evolution
-        test_schroedinger_gpu(AT, synchronize)
+        test_schroedinger_gpu(AT, synchronize; kwargs...)
     end
 end

--- a/test/gpu/implementation/test_schroedinger_gpu.jl
+++ b/test/gpu/implementation/test_schroedinger_gpu.jl
@@ -1,19 +1,20 @@
-function test_schroedinger_gpu(AT, synchronize)
+function test_schroedinger_gpu(AT, synchronize; time_eltype=Float64, solver_kwargs=(;), kwargs...)
     """Test Schrödinger time evolution on GPU arrays."""
-    
+
     @testset "Schrödinger Time Evolution GPU Tests" begin
-        
+        t_short = time_eltype.(T_SHORT)
+
         # Test 1: Basic Schrödinger evolution with single oscillator
         @testset "Single Oscillator" begin
             for n in test_sizes
-                H, gpu_H, psi0, gpu_psi0 = create_test_system(n, AT)
+                H, gpu_H, psi0, gpu_psi0 = create_test_system(n, AT; kwargs...)
                 
                 @test typeof(gpu_H.data) <: AT
                 @test typeof(gpu_psi0.data) <: AT
-                
+
                 # Run time evolution on CPU and GPU
-                t_cpu, psi_cpu = timeevolution.schroedinger(T_SHORT, psi0, H)
-                t_gpu, psi_gpu = timeevolution.schroedinger(T_SHORT, gpu_psi0, gpu_H)
+                t_cpu, psi_cpu = timeevolution.schroedinger(t_short, psi0, H; solver_kwargs...)
+                t_gpu, psi_gpu = timeevolution.schroedinger(t_short, gpu_psi0, gpu_H; solver_kwargs...)
                 synchronize()
                 
                 # Verify results match

--- a/test/gpu/implementation/utilities.jl
+++ b/test/gpu/implementation/utilities.jl
@@ -1,6 +1,6 @@
 # Utility functions for GPU time evolution testing
 
-function create_test_system(n, AT)
+function create_test_system(n, AT; storage_eltype=ComplexF64)
     """Create a test quantum system and adapt it to the specified array type."""
     # Create basis
     basis = FockBasis(n-1)
@@ -9,14 +9,16 @@ function create_test_system(n, AT)
     a = destroy(basis)
     at = create(basis)
     H = dense(at * a)  # Number operator Hamiltonian
-    
+    H = Operator(H.basis_l, H.basis_r, Matrix{storage_eltype}(H.data))
+
     # Create initial state
     psi0 = coherentstate(basis, 0.5)
-    
+    psi0 = Ket(psi0.basis, Vector{storage_eltype}(psi0.data))
+
     # Adapt to GPU
     gpu_H = Adapt.adapt(AT, H)
     gpu_psi0 = Adapt.adapt(AT, psi0)
-    
+
     return H, gpu_H, psi0, gpu_psi0
 end
 

--- a/test/gpu/test_platform_Metal.jl
+++ b/test/gpu/test_platform_Metal.jl
@@ -1,0 +1,25 @@
+@testitem "Metal" tags = [:metal] begin
+
+    include("implementation/test_platform.jl")
+
+    using Metal: MtlArray, Metal
+    const AT = MtlArray
+
+    const can_run = Metal.functional()
+
+    @testset "Device availability" begin
+        @test can_run
+    end
+
+    if can_run
+        synchronize() = Metal.synchronize(Metal.global_queue(Metal.device()))
+        test_platform(AT, synchronize;
+            storage_eltype=ComplexF32,
+            time_eltype=Float32,
+            solver_kwargs=(reltol=1f-6, abstol=1f-8, adaptive=false, dt=0.1f0)
+        )
+    else
+        @info "Skipping Metal tests - no devices available"
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,29 +1,33 @@
 # GPU test flags
-CUDA_flag = false
-AMDGPU_flag = false
-OpenCL_flag = false
+GPU_TEST = "false"
 
 if Sys.iswindows()
     @info "Skipping GPU tests -- only executed on *NIX platforms."
 else
-    CUDA_flag = get(ENV, "CUDA_TEST", "") == "true"
-    AMDGPU_flag = get(ENV, "AMDGPU_TEST", "") == "true"
-    OpenCL_flag = get(ENV, "OpenCL_TEST", "") == "true"
+    GPU_TEST = lowercase(get(ENV, "GPU_TEST", "false"))
+    if !(GPU_TEST in ("false", "cuda", "amdgpu", "opencl", "metal"))
+        error("GPU_TEST must be one of: false, cuda, amdgpu, opencl, metal")
+    end
 
-    CUDA_flag && @info "Running with CUDA tests."
-    AMDGPU_flag && @info "Running with AMDGPU tests."
-    OpenCL_flag && @info "Running with OpenCL tests."
-    if !any((CUDA_flag, AMDGPU_flag, OpenCL_flag))
+    if GPU_TEST == "false"
         @info "Skipping GPU tests -- must be explicitly enabled."
-        @info "Environment must set [CUDA, AMDGPU, OpenCL]_TEST=true."
+        @info "Environment must set GPU_TEST to one of: cuda, amdgpu, opencl, metal."
+    else
+        @info "Running with $(GPU_TEST) tests."
     end
 end
+
+CUDA_flag = GPU_TEST == "cuda"
+AMDGPU_flag = GPU_TEST == "amdgpu"
+OpenCL_flag = GPU_TEST == "opencl"
+Metal_flag = GPU_TEST == "metal"
 
 using Pkg
 CUDA_flag && Pkg.add("CUDA")
 AMDGPU_flag && Pkg.add("AMDGPU")
 OpenCL_flag && Pkg.add(["pocl_jll", "OpenCL"])
-if any((CUDA_flag, AMDGPU_flag, OpenCL_flag))
+Metal_flag && Pkg.add("Metal")
+if any((CUDA_flag, AMDGPU_flag, OpenCL_flag, Metal_flag))
     Pkg.add("Adapt")
 end
 
@@ -57,7 +61,13 @@ testfilter = ti -> begin
   else
     push!(exclude, :opencl)
   end
-  
+
+  if Metal_flag
+    return :metal in ti.tags
+  else
+    push!(exclude, :metal)
+  end
+
   if !(VERSION >= v"1.10")
     push!(exclude, :aqua)
   end


### PR DESCRIPTION
## Summary
- add a Metal.jl GPU platform test mirroring the existing CUDA/AMDGPU/OpenCL platform files
- let the shared GPU fixture use Float32 storage/adaptation for Metal while preserving existing defaults
- wire Metal tests into the test filter and Buildkite on the macmini queue

## Testing
- ENV["Metal_TEST"]="true"; Pkg.test()