### PR TITLE
Fix SciML solution indexing with RecursiveArrayTools v4

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,7 +1,7 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqLowOrderRK = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 QuantumOptics = "6e0679c1-51ea-5a7c-ac74-d61b76210b0c"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,6 +1,6 @@
 using BenchmarkTools
 using QuantumOptics
-using OrdinaryDiffEq
+using OrdinaryDiffEqLowOrderRK
 using StochasticDiffEq
 using LinearAlgebra
 using PkgBenchmark
@@ -21,10 +21,10 @@ function bench_schroedinger(dim; pure=true)
     t₀, t₁ = (0.0, pi)
     H = sigmax(b)
     psi0 = spindown(b)
-    if pure 
+    if pure
         obj = psi0.data
         Hobj = H.data
-    else 
+    else
         obj = psi0
         Hobj = H
     end
@@ -57,11 +57,11 @@ function bench_stochastic_schroedinger(dim; pure=true)
     H = sigmax(b)
     Hs = sigmay(b)
     psi0 = spindown(b)
-    if pure 
+    if pure
         obj = psi0.data
         Hobj = H.data
         Hsobj = Hs.data
-    else 
+    else
         obj = psi0
         Hobj = H
         Hsobj = Hs

--- a/test/test_ForwardDiff.jl
+++ b/test/test_ForwardDiff.jl
@@ -24,7 +24,7 @@ f_schrod!(dpsi, psi, p, t) = timeevolution.dschroedinger!(dpsi, H(p), psi)
 function cost_schrod(p)
     prob = ODEProblem(f_schrod!, psi0, (0.0, pi), p)
     sol = solve(prob, DP5(); save_everystep=false)
-    return 1 - norm(sol[end])
+    return 1 - norm(sol.u[end])
 end
 
 p = [rand(), rand()]

--- a/test/test_sciml_broadcast_interfaces.jl
+++ b/test/test_sciml_broadcast_interfaces.jl
@@ -21,7 +21,7 @@ prob = ODEProblem(f!, sc, (t₀, t₁))
 sol = solve(prob, DP5(); reltol = 1.0e-8, abstol = 1.0e-10, save_everystep=false)
 tout, ψt = semiclassical.schroedinger_dynamic([t₀, t₁], sc, fquantum, fclassical!; reltol = 1.0e-8, abstol = 1.0e-10)
 
-@test sol[end] ≈ ψt[end]
+@test sol.u[end] ≈ ψt[end]
 
 end
 end


### PR DESCRIPTION
## Summary
- update direct `ODESolution` timestep access in tests from `sol[end]` to `sol.u[end]`
- update the benchmark suite from the old `OrdinaryDiffEq` umbrella import/dependency to `OrdinaryDiffEqLowOrderRK`, where `DP5` now lives
- keep changes limited to the SciML breaking-change migrations needed by the recent compat bumps

## Release notes checked
- OrdinaryDiffEq v7 release notes / NEWS.md: `ODESolution` now follows `AbstractArray` indexing, so timestep access should use `sol.u[i]` or `sol[:, i]` instead of `sol[i]`
- OrdinaryDiffEq v7 split solver families into explicit subpackages; `DP5` is provided by `OrdinaryDiffEqLowOrderRK`
- StochasticDiffEq v7 is now an OrdinaryDiffEq monorepo umbrella over SDE solver subpackages
- General registry marks `OrdinaryDiffEqCore 5.0.0` as yanked; current test resolution uses `OrdinaryDiffEqCore 4.0.0` with `OrdinaryDiffEqLowOrderRK 2.0.0` and `StochasticDiffEq 7.0.0`

## Tests
- `JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia -tauto --project=. -e 'using Pkg; Pkg.test()'`
- `JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia -tauto --depwarn=error --project=. -e 'using Pkg; Pkg.test()'`
- `JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager julia -tauto --project=benchmark -e 'include("benchmark/benchmarks.jl"); solve(bench_schroedinger(1//2; pure=true), DP5(); save_everystep=false); solve(bench_stochastic_schroedinger(1//2; pure=true), EM(), dt=1/100; save_everystep=false)'`

## Deprecation pass
- `--depwarn=error` test run passed, so there were no in-repo deprecation warnings to address in a dedicated deprecation commit.
