### PR TITLE
Fix documentation warning checks

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -108,7 +108,7 @@ makedocs(
         size_threshold_warn = 300 * 2^10,
     ),
     checkdocs = :exports,
-    warnonly = [:docs_block, :missing_docs, :cross_references],
+    warnonly = [:missing_docs],
 )
 
 deploydocs(

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -107,7 +107,7 @@ makedocs(
         size_threshold = 400 * 2^10,
         size_threshold_warn = 300 * 2^10,
     ),
-    checkdocs = :exports,
+    checkdocs = :public,
     warnonly = [:missing_docs],
 )
 

--- a/docs/src/.gitignore
+++ b/docs/src/.gitignore
@@ -1,1 +1,0 @@
-/examples/

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -59,11 +59,6 @@ DenseOperator
 SparseOperator
 ```
 
-```@docs; canonical=false
-LazyKet
-```
-
-
 ```@docs
 LazyTensor
 ```
@@ -251,10 +246,6 @@ sparse(::AbstractOperator)
 current_time
 ```
 
-```@docs; canonical=false
-static_operator
-```
-
 ```@docs
 set_time!
 ```
@@ -354,36 +345,6 @@ wignersu2
 
 ```@docs
 ylm
-```
-
-### [Charge](@id API: Charge operators)
-
-```@docs; canonical=false
-ChargeBasis
-```
-
-```@docs; canonical=false
-ShiftedChargeBasis
-```
-
-```@docs; canonical=false
-chargestate
-```
-
-```@docs; canonical=false
-chargeop
-```
-
-```@docs; canonical=false
-expiφ
-```
-
-```@docs; canonical=false
-cosφ
-```
-
-```@docs; canonical=false
-sinφ
 ```
 
 ### [N-level](@id API: N-level)
@@ -550,10 +511,6 @@ sparseprojector
 
 ```@docs
 ManyBodyBasis
-```
-
-```@docs; canonical=false
-FermionBitstring
 ```
 
 ```@docs

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -59,8 +59,9 @@ DenseOperator
 SparseOperator
 ```
 
-```@docs
+```@docs; canonical=false
 LazyKet
+```
 
 
 ```@docs
@@ -250,7 +251,7 @@ sparse(::AbstractOperator)
 current_time
 ```
 
-```@docs
+```@docs; canonical=false
 static_operator
 ```
 
@@ -355,33 +356,33 @@ wignersu2
 ylm
 ```
 
-### [Charge](@id API: Charge)
+### [Charge](@id API: Charge operators)
 
-```@docs
+```@docs; canonical=false
 ChargeBasis
 ```
 
-```@docs
+```@docs; canonical=false
 ShiftedChargeBasis
 ```
 
-```@docs
+```@docs; canonical=false
 chargestate
 ```
 
-```@docs
+```@docs; canonical=false
 chargeop
 ```
 
-```@docs
+```@docs; canonical=false
 expiφ
 ```
 
-```@docs
+```@docs; canonical=false
 cosφ
 ```
 
-```@docs
+```@docs; canonical=false
 sinφ
 ```
 
@@ -551,7 +552,7 @@ sparseprojector
 ManyBodyBasis
 ```
 
-```@docs
+```@docs; canonical=false
 FermionBitstring
 ```
 


### PR DESCRIPTION
## Summary
- fix the malformed `LazyKet` API `@docs` block without removing the API entry
- mark repeated API entries as `canonical=false` so they remain listed without duplicate-doc warnings
- leave `makedocs` with `warnonly = [:missing_docs]`
- remove `docs/src/.gitignore` so it is not copied into `docs/build` and does not make deployed examples ignored

## Notes
- `QuantumOpticsBase` was already loaded and included in `doc_modules`.
- No generated `docs/src/examples` files are committed; they remain ignored by the root `.gitignore` and are generated during the docs build.

## Testing
- `julia -tauto --project=docs docs/make.jl`
- clean `docs/build` fast rebuild confirmed `docs/build/examples` exists and no `docs/build/.gitignore` is produced
- warning scan of docs log only found the local deploy auto-detection warning
- `git diff --cached HEAD^ --check` before amend
- whitespace checks on `docs/src/api.md` and `docs/make.jl`