### PR TITLE
Update example notebook source links

### DIFF
--- a/docs/examples/notebooks/atom-dephasing.ipynb
+++ b/docs/examples/notebooks/atom-dephasing.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/atom-dephasing.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/atom-dephasing.ipynb)\n",
     "\n",
     "# Two-level atom driven by a noisy laser"
    ]

--- a/docs/examples/notebooks/cavity-cooling.ipynb
+++ b/docs/examples/notebooks/cavity-cooling.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/cavity-cooling.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/cavity-cooling.ipynb)\n",
     "\n",
     "# Cavity cooling of a two-level atom"
    ]

--- a/docs/examples/notebooks/correlation-spectrum.ipynb
+++ b/docs/examples/notebooks/correlation-spectrum.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/correlation-spectrum.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/correlation-spectrum.ipynb)\n",
     "\n",
     "# Two-time correlation function and spectrum of a Fock state"
    ]

--- a/docs/examples/notebooks/doppler-cooling.ipynb
+++ b/docs/examples/notebooks/doppler-cooling.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/doppler-cooling.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/doppler-cooling.ipynb)\n",
     "\n",
     "# Doppler cooling"
    ]

--- a/docs/examples/notebooks/jaynes-cummings.ipynb
+++ b/docs/examples/notebooks/jaynes-cummings.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/jaynes-cummings.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/jaynes-cummings.ipynb)\n",
     "\n",
     "# Jaynes-Cummings model"
    ]

--- a/docs/examples/notebooks/lasing-and-cooling.ipynb
+++ b/docs/examples/notebooks/lasing-and-cooling.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/lasing-and-cooling.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/lasing-and-cooling.ipynb)\n",
     "\n",
     "# Simultaneous Lasing, Cooling and Trapping"
    ]

--- a/docs/examples/notebooks/manybody-fourlevel-system.ipynb
+++ b/docs/examples/notebooks/manybody-fourlevel-system.ipynb
@@ -7,7 +7,7 @@
     "editable": true
    },
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/manybody-fourlevel-system.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/manybody-fourlevel-system.ipynb)\n",
     "\n",
     "# Four level system in many-body formalism\n",
     "\n",

--- a/docs/examples/notebooks/nparticles-in-double-well.ipynb
+++ b/docs/examples/notebooks/nparticles-in-double-well.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/nparticles-in-double-well.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/nparticles-in-double-well.ipynb)\n",
     "\n",
     "# N-Particles in a double-well potential\n",
     "In this example we will first solve the problem of a single particle in a double well potential. We then will assume that the particle is always trapped in one of the low energy states. This allows us to reduce the Hilbert space of the system to these states only. Using this reduced Hilbert space we will investigate the case of N indistinguishable particles in such a system. Finally we will add particle-particle interaction to obtain a more interesting problem."

--- a/docs/examples/notebooks/optomech-cooling.ipynb
+++ b/docs/examples/notebooks/optomech-cooling.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/optomech-cooling.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/optomech-cooling.ipynb)\n",
     "\n",
     "# Optomechanical Cavity\n",
     "\n",

--- a/docs/examples/notebooks/particle-in-harmonic-trap.ipynb
+++ b/docs/examples/notebooks/particle-in-harmonic-trap.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/particle-in-harmonic-trap.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/particle-in-harmonic-trap.ipynb)\n",
     "\n",
     "# Particle in harmonic trap potential"
    ]

--- a/docs/examples/notebooks/particle-into-barrier.ipynb
+++ b/docs/examples/notebooks/particle-into-barrier.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/particle-into-barrier.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/particle-into-barrier.ipynb)\n",
     "\n",
     "# Gaussian wave packet running into a potential barrier"
    ]

--- a/docs/examples/notebooks/pumped-cavity.ipynb
+++ b/docs/examples/notebooks/pumped-cavity.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/pumped-cavity.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/pumped-cavity.ipynb)\n",
     "\n",
     "# Pumped cavity"
    ]

--- a/docs/examples/notebooks/quantum-kicked-top.ipynb
+++ b/docs/examples/notebooks/quantum-kicked-top.ipynb
@@ -6,7 +6,7 @@
     "collapsed": true
    },
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/quantum-kicked-top.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/quantum-kicked-top.ipynb)\n",
     "\n",
     "# Quantum kicked top"
    ]

--- a/docs/examples/notebooks/quantum-zeno-effect.ipynb
+++ b/docs/examples/notebooks/quantum-zeno-effect.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/quantum-zeno-effect.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/quantum-zeno-effect.ipynb)\n",
     "\n",
     "# Quantum Zeno Effect"
    ]

--- a/docs/examples/notebooks/raman.ipynb
+++ b/docs/examples/notebooks/raman.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/raman.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/raman.ipynb)\n",
     "\n",
     "\n",
     "# Raman Transition of a $\\Lambda$-scheme Atom"

--- a/docs/examples/notebooks/ramsey.ipynb
+++ b/docs/examples/notebooks/ramsey.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/ramsey.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/ramsey.ipynb)\n",
     "\n",
     "Ramsey spectroscopy of two-level atom ensemble\n",
     "========================="

--- a/docs/examples/notebooks/spin-orbit-coupled-BEC1D.ipynb
+++ b/docs/examples/notebooks/spin-orbit-coupled-BEC1D.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/spin-orbit-coupled-BEC1D.ipynb)\n",
+    "\n",
     "# Spin-orbit coupling in Bose-Einstein Condensates"
    ]
   },

--- a/docs/examples/notebooks/superradiant-laser.ipynb
+++ b/docs/examples/notebooks/superradiant-laser.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/superradiant-laser.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/superradiant-laser.ipynb)\n",
     "\n",
     "# Superradiant laser"
    ]

--- a/docs/examples/notebooks/three-level-maser.ipynb
+++ b/docs/examples/notebooks/three-level-maser.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/three-level-maser.ipynb)\n",
+    "\n",
     "# Heat-pumped three-level maser\n",
     "\n",
     "Consider a three-level atom that interacts with two heat baths at temperatures $T_\\mathrm{c}$ and $T_\\mathrm{h}$, respectively, and a single cavity field mode. The cavity mode is further coupled to an environment at temperature $T_\\mathrm{env}$.\n",

--- a/docs/examples/notebooks/two-qubit-entanglement.ipynb
+++ b/docs/examples/notebooks/two-qubit-entanglement.ipynb
@@ -8,7 +8,7 @@
     "editable": true
    },
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/two-qubit-entanglement.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/two-qubit-entanglement.ipynb)\n",
     "\n",
     "# Entanglement of Two Qubits"
    ]

--- a/docs/examples/notebooks/vortex.ipynb
+++ b/docs/examples/notebooks/vortex.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/vortex.ipynb)\n",
+    "\n",
     "# Quantum Vortices"
    ]
   },

--- a/docs/examples/notebooks/wavepacket2D.ipynb
+++ b/docs/examples/notebooks/wavepacket2D.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl-examples/tree/master/notebooks/wavepacket2D.ipynb)\n",
+    "*This notebook can be found on* [github](https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/wavepacket2D.ipynb)\n",
     "\n",
     "# Dynamics of a two-dimensional wavepacket hitting a Gaussian potential"
    ]


### PR DESCRIPTION
Updates the first markdown cell in the existing example notebooks to point at their new in-repository location under `docs/examples/notebooks` instead of the archived `QuantumOptics.jl-examples` repository.

The bulk replacement was done with:

```bash
perl -0pi -e 's|https://github\\.com/qojulia/QuantumOptics\\.jl-examples/tree/master/notebooks/|https://github.com/qojulia/QuantumOptics.jl/tree/master/docs/examples/notebooks/|g' docs/examples/notebooks/*.ipynb\n```\n\nThree notebooks did not previously have the source-location line, so I added it with a filename-derived looped substitution.\n\nValidation:\n- `rg "QuantumOptics\\.jl-examples/tree/master/notebooks" docs/examples/notebooks` returns no matches.\n- `jq` check confirms every first cell contains the new URL plus its notebook filename.