### PR TITLE
Require current TestItemRunner in downgrade tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -13,3 +13,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
+
+[compat]
+TestItemRunner = "1.1.5"


### PR DESCRIPTION
## Summary

- set the test-environment TestItemRunner lower bound to 1.1.5, the latest General-registry release
- prevent minimum-dependency CI from selecting TestItemRunner 0.1.0, which lacks the filtered run_package_tests macro API used by this suite

## Validation

- Project.toml and test/Project.toml parse with Julia 1.12.6
- git diff --check
- hosted downgrade CI provides the locked minimum-version integration test

The current master downgrade run also has an independent LinearSolve/MKL_jll precompile failure; this PR addresses only the recurrent test-runner setup issue.